### PR TITLE
create backup dir if it not exists (ansible 1.9.x)

### DIFF
--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -9,6 +9,12 @@
         To permit automatic upgrades set 'rocket_chat_automatic_upgrades' to true
     when: not rocket_chat_automatic_upgrades|bool
 
+  - name: Create Back up directory if it not exists [UPGRADE]
+    file:
+      path: "{{ rocket_chat_application_path }}"
+      state: directory
+    when: rocket_chat_upgrade_backup|bool
+
   - name: Back up the current Rocket.Chat instance [UPGRADE]
     shell: >-
       mv {{ rocket_chat_application_path }}/bundle


### PR DESCRIPTION
In the case of the back dir directory does not exist runs the ansible script  in an error.