### PR TITLE
General increase of idempotency + handling of mishaps when setting wrong sha256sum

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rocket_chat_upgrade_backup_path: "{{ rocket_chat_application_path }}"
 rocket_chat_application_path: /var/lib/rocket.chat
 rocket_chat_version: latest
 rocket_chat_tarball_remote: https://rocket.chat/releases/{{ rocket_chat_version }}/download
-rocket_chat_tarball_sha256sum: ca3229ac2880739f1fde0c771fa8604fffedf81676e15e95f9baebb0ec556289
+rocket_chat_tarball_sha256sum: 2bee49931331ebe1c5985f08db74dd93150ace3ead4404244176e2fffb657780
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true
 rocket_chat_service_user: rocketchat

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,12 @@ rocket_chat_application_path: /var/lib/rocket.chat
 rocket_chat_version: latest
 rocket_chat_tarball_remote: https://rocket.chat/releases/{{ rocket_chat_version }}/download
 rocket_chat_tarball_sha256sum: 2bee49931331ebe1c5985f08db74dd93150ace3ead4404244176e2fffb657780
+rocket_chat_tarball_sha256sum_short: "{{ rocket_chat_tarball_sha256sum | truncate(7, True, '') }}"
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true
+rocket_chat_tarball_new: "{{ rocket_chat_temp_bundle_dir }}/rocket.chat-{{ rocket_chat_tarball_sha256sum_short }}.tgz"
+rocket_chat_tarball_current: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
+rocket_chat_temp_bundle_dir: "{{ rocket_chat_application_path }}/{{ rocket_chat_tarball_sha256sum_short }}"
 rocket_chat_service_user: rocketchat
 rocket_chat_service_group: rocketchat
 rocket_chat_service_host: "{{ ansible_fqdn }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,12 @@
     tags:
       - upgrade
 
+  - name: Install Rocket.Chat
+    include: install.yml
+    tags:
+      - install
+      - upgrade
+
   - name: Update the Rocket.Chat service configuration
     shell: "{{ rocket_chat_service_update_command }}"
     when: rocket_chat_service_update_command is defined

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,24 @@
+
+  - name: Delete the current Rocket.Chat instance [INSTALL]
+    file:
+      path: "{{ rocket_chat_application_path }}/bundle"
+      state: absent
+
+  - name: Move the unpacked Rocket.Chat binary tarball into place [INSTALL]
+    shell: >-
+      mv
+      "{{ rocket_chat_temp_bundle_dir }}/bundle"
+      "{{ rocket_chat_application_path }}/bundle"
+    args:
+      removes: "{{ rocket_chat_temp_bundle_dir }}/bundle"
+    become: true
+    become_user: "{{ rocket_chat_service_user }}"
+
+  - name: Hardlink the new Rocket.Chat tarball to be the current tarball [INSTALL]
+    file:
+      force: yes
+      state: hard
+      src: "{{ rocket_chat_tarball_new }}"
+      path: "{{ rocket_chat_tarball_current }}"
+      owner: "{{ rocket_chat_service_user }}"
+      group: "{{ rocket_chat_service_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,7 +108,7 @@
     become: true
     become_user: "{{ rocket_chat_service_user }}"
     tags: build
-      
+
   - name: Install Rocket.Chat via NPM
     npm:
       state: present
@@ -194,7 +194,7 @@
   - name: Ensure the Rocket.Chat service is running/enabled
     service: name=rocketchat state=started enabled=true
     tags: service
-  
+
   - include: nginx.yml
     when: rocket_chat_include_nginx|bool
     tags: nginx

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,7 +89,7 @@
   - name: Fetch the Rocket.Chat binary tarball
     get_url:
       url: "{{ rocket_chat_tarball_remote }}"
-      sha256sum: "{{ rocket_chat_tarball_sha256sum }}"
+      checksum: "sha256:{{ rocket_chat_tarball_sha256sum }}"
       dest: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
       timeout: "{{ rocket_chat_tarball_fetch_timeout }}"
       validate_certs: "{{ rocket_chat_tarball_validate_remote_cert }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,6 +91,7 @@
       url: "{{ rocket_chat_tarball_remote }}"
       checksum: "sha256:{{ rocket_chat_tarball_sha256sum }}"
       dest: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
+      force: yes
       timeout: "{{ rocket_chat_tarball_fetch_timeout }}"
       validate_certs: "{{ rocket_chat_tarball_validate_remote_cert }}"
     notify: Upgrade Rocket.Chat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,12 +19,6 @@
     when: rocket_chat_include_mongodb|bool
     tags: mongodb
 
-  - name: Ensure the Rocket.Chat service group is present
-    group:
-      name: "{{ rocket_chat_service_group }}"
-      state: present
-      system: true
-
   - name: Ensure the Rocket.Chat service user is present
     user:
       comment: Rocket.Chat Service User
@@ -33,6 +27,12 @@
       home: "{{ rocket_chat_application_path }}"
       createhome: true
       shell: /bin/false
+      state: present
+      system: true
+
+  - name: Ensure the Rocket.Chat service group is present
+    group:
+      name: "{{ rocket_chat_service_group }}"
       state: present
       system: true
 
@@ -86,29 +86,54 @@
     set_fact:
       rocket_chat_upgraded: false
 
-  - name: Fetch the Rocket.Chat binary tarball
+  - name: Create temporary tarball/bundle directory
+    file:
+      path: "{{ rocket_chat_temp_bundle_dir }}"
+      state: directory
+    become: true
+    become_user: "{{ rocket_chat_service_user }}"
+
+  - name: Fetch the Rocket.Chat binary tarball into a temp location
     get_url:
       url: "{{ rocket_chat_tarball_remote }}"
       checksum: "sha256:{{ rocket_chat_tarball_sha256sum }}"
-      dest: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
-      force: yes
+      dest: "{{ rocket_chat_tarball_new }}"
       timeout: "{{ rocket_chat_tarball_fetch_timeout }}"
       validate_certs: "{{ rocket_chat_tarball_validate_remote_cert }}"
-    notify: Upgrade Rocket.Chat
     become: true
     become_user: "{{ rocket_chat_service_user }}"
+
+  - name: Unpack the Rocket.Chat binary into a temp location
+    unarchive:
+      copy: false
+      src: "{{ rocket_chat_tarball_new }}"
+      dest: "{{ rocket_chat_temp_bundle_dir }}"
+    become: true
+    become_user: "{{ rocket_chat_service_user }}"
+
+  - name: Recursively diff both unpacked bundles to determine if a Rocket.Chat upgrade is necessary
+      # These should be identical if nothing changed, sans node_modules, hence -x
+    shell: >-
+      diff -rq -x'node_modules'
+      "{{ rocket_chat_temp_bundle_dir | quote }}/bundle"
+      "{{ rocket_chat_application_path | quote }}/bundle"
+      >/dev/null
+    register: diff_result
+    changed_when: "diff_result.rc != 0" # 1 is different, 2 is error
+    failed_when: false
+    notify:
+      - Upgrade Rocket.Chat
+      - Install Rocket.Chat
+    tags:
+      - install
+      - upgrade
 
   - meta: flush_handlers
 
-  - name: Unpack the Rocket.Chat binary tarball
-    unarchive:
-      copy: false
-      src: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
-      dest: "{{ rocket_chat_application_path }}"
-      creates: "{{ rocket_chat_application_path }}/bundle"
-    become: true
-    become_user: "{{ rocket_chat_service_user }}"
-    tags: build
+  - name: Remove temporary archive dir if present
+    file:
+      path: "{{ rocket_chat_temp_bundle_dir }}"
+      state: absent
 
   - name: Install Rocket.Chat via NPM
     npm:

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -15,17 +15,20 @@
       state: directory
     when: rocket_chat_upgrade_backup|bool
 
+  - name: Check if a backup was already made today [UPGRADE]
+    stat:
+      path: "{{ rocket_chat_upgrade_backup_path }}/backup_{{ ansible_date_time.date }}"
+    register: rocket_chat_upgrade_backup_dir_stat
+
   - name: Back up the current Rocket.Chat instance [UPGRADE]
     shell: >-
-      mv {{ rocket_chat_application_path }}/bundle
-      {{ rocket_chat_upgrade_backup_path }}/backup_{{ ansible_date_time.date }}
+      mv -f
+      "{{ rocket_chat_application_path }}/bundle"
+      "{{ rocket_chat_upgrade_backup_path }}/backup_{{ ansible_date_time.date }}"
+    args:
+      removes: "{{ rocket_chat_application_path }}/bundle"
     when: rocket_chat_upgrade_backup|bool
-
-  - name: Delete the current Rocket.Chat instance [UPGRADE]
-    file:
-      path: "{{ rocket_chat_application_path }}/bundle"
-      state: absent
-    when: not rocket_chat_upgrade_backup|bool
+          and not rocket_chat_upgrade_backup_dir_stat.stat.exists
 
   - name: Set the Rocket.Chat upgrade status [UPGRADE]
     set_fact:

--- a/templates/rocket_chat.conf.j2
+++ b/templates/rocket_chat.conf.j2
@@ -1,5 +1,5 @@
 upstream rocket_chat {
-        server 127.0.0.1:3000;
+        server 127.0.0.1:{{ rocket_chat_service_port }};
 }
 server {
         listen  80;


### PR DESCRIPTION
This is currently the state of the role that I have been using myself in
a forked repository. Some notable points:

- Added 4 variables to defaults/main.yml to simplify line lengths /
undertanding in playbooks
- Added an install.yml in tasks/ as a handler for install related
tasks (where upgrade.yml still handles backup-related)
- Moved the group check after the user check, because if the user is
created it is created by default with its group, so the check is
essentially causing the group/user to diverge because it creates the
group first, then the user
- Instead of using a static name for the new tarball, we take the
short sha256 and append that to the name - this prevents issues when you
don't set the sha256sum properly during an update
- Instead of blindly clobbering the backup, check to see if we've
backed up in the same day and don't move the current bundle into a
backup if we have.
    - This replaces the "Delete the current..." task
- Use ` checksum: sha256:` over `sha256sum` as it is deprecated 