### PR TITLE
Remove forever daemon in lieu of plain Upstart on Ubuntu 14

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,14 +57,6 @@
       global: true
       executable: "{{ rocket_chat_original_npm }}"
 
-  - name: Ensure Forever (NodeJS) is installed [Ubuntu 14]
-    npm:
-      name: forever
-      global: yes
-      executable: "{{ rocket_chat_original_npm }}"
-    when: (ansible_distribution == "Ubuntu")
-          and (ansible_distribution_major_version == "14")
-
   - name: Check to see if n has installed the required 'node' binary
     stat:
       path: "{{ rocket_chat_node_10_40_path }}/node"
@@ -140,37 +132,15 @@
     become_user: "{{ rocket_chat_service_user }}"
     tags: build
 
-  - name: Check to see if the Rocket.Chat log file is present [Ubuntu 14]
-    stat: path=/var/log/rocketchat.log
-    register: rocket_chat_log_file_state
-    when: (ansible_distribution == "Ubuntu")
-          and (ansible_distribution_major_version == "14")
-
-  - name: Ensure the Rocket.Chat log file is present [Ubuntu 14]
+  - name: Ensure the Rocket.Chat log file symlink is present [Ubuntu 14]
     file:
       path: /var/log/rocketchat.log
-      state: touch
-      owner: "{{ rocket_chat_service_user }}"
-      group: "{{ rocket_chat_service_group }}"
-    when: (ansible_distribution == "Ubuntu")
-          and (ansible_distribution_major_version == "14")
-          and not rocket_chat_log_file_state.stat.exists
+      src: /var/log/upstart/rocketchat.log
+      state: link
+      force: yes
 
-  - name: Check to see if the Rocket.Chat pid file is present [Ubuntu 14]
-    stat: path=/var/run/rocketchat.pid
-    register: rocket_chat_pid_file_state
     when: (ansible_distribution == "Ubuntu")
           and (ansible_distribution_major_version == "14")
-
-  - name: Ensure the Rocket.Chat pid file is present [Ubuntu 14]
-    file:
-      path: /var/run/rocketchat.pid
-      state: touch
-      owner: "{{ rocket_chat_service_user }}"
-      group: "{{ rocket_chat_service_group }}"
-    when: (ansible_distribution == "Ubuntu")
-          and (ansible_distribution_major_version == "14")
-          and not rocket_chat_pid_file_state.stat.exists
 
   - name: Ensure the Rocket.Chat application data permissions are correct
     file:

--- a/templates/rocketchat_upstart.j2
+++ b/templates/rocketchat_upstart.j2
@@ -1,23 +1,19 @@
 #!upstart
 #
 # Rocket.Chat upstart script
-# This upstart script makes use of Forever : https://github.com/nodejitsu/forever
-
 
 description "Rocket.Chat Server"
- 
+
 start on startup
 stop on shutdown
- 
-expect fork
- 
+
+console log
+respawn
+respawn limit 10 5
+
 env NODE_BIN_DIR="{{ rocket_chat_node_10_40_path }}"
 env NODE_PATH="/usr/local/lib/node_modules"
 env APPLICATION_PATH="{{ rocket_chat_application_path }}/bundle/main.js"
-env PIDFILE="/var/run/rocketchat.pid"
-env LOG="/var/log/rocketchat.log"
-env MIN_UPTIME="5000"
-env SPIN_SLEEP_TIME="2000"
 
 chdir {{ rocket_chat_application_path }}
 setuid {{ rocket_chat_service_user }}
@@ -28,20 +24,7 @@ env MONGO_OPLOG_URL="mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket_chat_m
 env ROOT_URL="https://{{ rocket_chat_service_host }}"
 env PORT="{{ rocket_chat_service_port }}"
 
-
 script
     PATH=$NODE_BIN_DIR:$PATH
-
-    exec forever \
-      --pidFile $PIDFILE \
-      -a \
-      -l $LOG \
-      --minUptime $MIN_UPTIME \
-      --spinSleepTime $SPIN_SLEEP_TIME \
-      start $APPLICATION_PATH
-end script
-
-pre-stop script
-    PATH=$NODE_BIN_DIR:$PATH
-    exec forever stop $APPLICATION_PATH
+    node $APPLICATION_PATH
 end script


### PR DESCRIPTION
The previous method of using the forever monitor daemon with upstart
failed at being able to write to the pid-file upon reboot. This showed
up in Vagrant testing and I believe it has something to do with the fact
that we're creating the pidfile manually within the play.

I have prior experience with NodeJS+Upstart and it turns out that
forever isn't actually necessary at all. With `console log` and
`respawn` directives, and an unforked process, Upstart properly tracks
the PID (without a pidfile), respawns the process should it die, and
logs by default to `/var/log/upstart/rocketchat.log`

This changeset removes the following tasks and has the added benefit of
simplifying the play overall:

- Ensure Forever (NodeJS) is installed [Ubuntu 14]
- Check to see if the Rocket.Chat log file is present [Ubuntu 14]
- Ensure the Rocket.Chat log file is present [Ubuntu 14]
- Ensure the Rocket.Chat pid file is present [Ubuntu 14]

The former log-file path has been replaced with a symlink pointing to
the new logfile path.

This fixes #11