### PR TITLE
Adding httpd_sys_content_t role for selinux to allow folder access

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -13,6 +13,8 @@
     path: "{{ rocket_chat_letsencrypt_wellknown_path  }}"
     state: directory
     owner: "{{ rocket_chat_nginx_process_user }}"
+    setype: httpd_sys_content_t
+    recurse: yes
 
 - name: Generate acme-tiny Let's Encrypt account key [Let's Encrypt!]
   shell: >-


### PR DESCRIPTION
The let's encrypt part works like a charm. I had to add one small change to make it work when selinux is enabled which will otherwise block access to /var/www/letsencrypt.
Only ran this on CentOS 7.