### PR TITLE
Support for Jessie (debain 8)

### DIFF
--- a/vars/Debian_8.yml
+++ b/vars/Debian_8.yml
@@ -4,4 +4,4 @@ rocket_chat_service_template:
   src: rocketchat.service.j2
   dest: /etc/systemd/system/rocketchat.service
 
-rocket_chat_mongodb_apt_repo: "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main"
+rocket_chat_mongodb_apt_repo: "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main"


### PR DESCRIPTION
You can use `lsb_release -sc` instead of the name of the verssion like Jessie or Wheezy