### PR TITLE
Update default tarball URI after RC website update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ rocket_chat_upgrade_backup: true
 rocket_chat_upgrade_backup_path: "{{ rocket_chat_application_path }}"
 rocket_chat_application_path: /var/lib/rocket.chat
 rocket_chat_version: latest
-rocket_chat_tarball_remote: https://rocket.chat/releases/{{ rocket_chat_version }}/download
+rocket_chat_tarball_remote: https://cdn-download.rocket.chat/build/rocket.chat-{{ rocket_chat_version }}.tgz
 rocket_chat_tarball_sha256sum: e001895f4319f34b0bc6d68af03ced3ac32a6715d98ffcab88f7d89b44ae4f98
 rocket_chat_tarball_check_checksum: true
 rocket_chat_tarball_fetch_timeout: 100


### PR DESCRIPTION
The website of Rocket.Chat has recently been updated.The default of `{{rocket_chat_tarball_remote}}` assumed an URL that was not working anymore and is hereby fixed.