### PR TITLE
Update node hash

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rocket_chat_upgrade_backup_path: "{{ rocket_chat_application_path }}"
 rocket_chat_application_path: /var/lib/rocket.chat
 rocket_chat_version: stable
 rocket_chat_tarball_remote: https://download.rocket.chat/{{ rocket_chat_version }}
-rocket_chat_tarball_sha256sum: e001895f4319f34b0bc6d68af03ced3ac32a6715d98ffcab88f7d89b44ae4f98
+rocket_chat_tarball_sha256sum: 35bdf90350ad3a0789edcbebe51e421b1f82b06c22278b504f2215fa0e962b56
 rocket_chat_tarball_check_checksum: true
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true
@@ -14,7 +14,7 @@ rocket_chat_service_user: rocketchat
 rocket_chat_service_group: rocketchat
 rocket_chat_service_host: "{{ ansible_fqdn }}"
 rocket_chat_service_port: 3000
-rocket_chat_node_version: 4.5.0
+rocket_chat_node_version: 4.8.4
 rocket_chat_node_path: /usr/local/n/versions/node/{{ rocket_chat_node_version }}/bin
 rocket_chat_node_orig_npm: /usr/bin/npm
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -183,6 +183,7 @@
     become: yes
     become_user: mongodb
     args:
+      executable: /bin/bash
       chdir: /var/lib/mongodb
       creates: /var/lib/mongodb/.mongo_rs_initialised
     when: rocket_chat_include_mongodb|bool

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -5,7 +5,8 @@
     shell: setsebool httpd_can_network_connect on -P
     changed_when: false
     when: (ansible_selinux is defined) and
-          (ansible_selinux.status != "disabled")
+          (ansible_selinux != false) and
+          (ansible_selinux.status == "enabled")
 
   - name: Ensure Nginx is present
     package:


### PR DESCRIPTION
Workaround: Fix mongodb user on centos with /sbin/nologin - new bug in 2.4.0

  - Needs executable on users with /sbin/nologin or /sbin/false because
    it uses $SHELL:

  - https://github.com/ansible/ansible/issues/26741#issuecomment-315177251

Fix SELinux conditional in new versions of ansible

  -  New versions of ansible don't leave ansible_selinux unset if it's not
    present on the system, probably rightfully so it now defines it as
    'false'. Closes #43

defaults/main.yml: Update hash and node_version