### PR TITLE
Fix sha256 hash for 0.59.3 release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rocket_chat_upgrade_backup_path: "{{ rocket_chat_application_path }}"
 rocket_chat_application_path: /var/lib/rocket.chat
 rocket_chat_version: stable
 rocket_chat_tarball_remote: https://download.rocket.chat/{{ rocket_chat_version }}
-rocket_chat_tarball_sha256sum: 35bdf90350ad3a0789edcbebe51e421b1f82b06c22278b504f2215fa0e962b56
+rocket_chat_tarball_sha256sum: 6dde19f4f09987b48d2e037042b8d95a298685584faccd37485aa587dbcada41
 rocket_chat_tarball_check_checksum: true
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true


### PR DESCRIPTION
With the release of 0.59.3, installation of the tarball fails with a checksum error.

As a general rule of thumb, when using checksums the version itself should be locked to a fixed version. This avoids the issue that end user installation fails because of checksum errors which require investigation (did the binary change or did somebody just forget to update the checksum after a release?)