### PR TITLE
Enable PGP Verification:

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,13 @@ rocket_chat_application_path: /var/lib/rocket.chat
 # "latest" implies latest stable here, can be "0.61.2", for example
 rocket_chat_version: latest
 rocket_chat_tarball_remote: https://releases.rocket.chat/{{ rocket_chat_version }}/download
-# SHA256 is version 0.61.2
-rocket_chat_tarball_sha256sum: 5131806173af17af73b736366c2163d453ecb7de892a2bcc817667d10b9d8fb9
-rocket_chat_tarball_check_checksum: true
+rocket_chat_tarball_asc_remote:  https://releases.rocket.chat/{{ rocket_chat_version }}/asc
+# Using the sha256sum is deprecated in favor of GPG verifying
+rocket_chat_tarball_sha256sum: 0
+rocket_chat_tarball_gpg_key: 0E163286C20D07B9787EBE9FD7F9D0414FD08104
+rocket_chat_tarball_gpg_keyserver: ha.pool.sks-keyservers.net
+rocket_chat_tarball_check_checksum: false
+rocket_Chat_tarball_check_pgp: true
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true
 rocket_chat_service_user: rocketchat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,10 +137,35 @@
       - ansible_distribution == "Ubuntu"
       - ansible_distribution_major_version == "16"
 
+  - name: Setup PGP for verifying the Rocket.Chat tarball
+    block:
+
+    - name: Import RochetChat PGP Key from default keyservers
+      shell: |
+        gpg --keyserver "{{ rocket_chat_tarball_gpg_keyserver }}" \
+            --recv-keys "{{ rocket_chat_tarball_gpg_key }}"
+      register: add_key
+      changed_when: "'not changed' not in add_key.stderr"
+      retries: 4
+
+    - name: Fetch the Rocket.Chat binary tarball PGP signature
+      get_url:
+        url: "{{ rocket_chat_tarball_asc_remote }}"
+        force: yes
+        dest: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.asc"
+        timeout: "{{ rocket_chat_tarball_fetch_timeout }}"
+        validate_certs: "{{ rocket_chat_tarball_validate_remote_cert }}"
+        owner: "{{ rocket_chat_service_user }}"
+        group: "{{ rocket_chat_service_group }}"
+      retries: 2
+
+    when: rocket_Chat_tarball_check_pgp
+    tags: pgp
+
   - name: Fetch the Rocket.Chat binary tarball
     get_url:
       url: "{{ rocket_chat_tarball_remote }}"
-      checksum: "{{ (rocket_chat_tarball_check_checksum == false) | ternary(omit, 'sha256: ' + rocket_chat_tarball_sha256sum) }}"
+      checksum: "{{ (rocket_chat_tarball_check_checksum == false) | ternary(omit, 'sha256: ' + (rocket_chat_tarball_sha256sum|string)) }}"
       force: "{{ (rocket_chat_tarball_check_checksum == false) | ternary('yes', omit) }}"
       dest: "{{ rocket_chat_application_path }}/rocket.chat-{{ rocket_chat_version }}.tgz"
       timeout: "{{ rocket_chat_tarball_fetch_timeout }}"
@@ -155,6 +180,16 @@
     until: result | succeeded
     changed_when: (result|changed)
                   or (not rocket_chat_tarball_check_checksum)
+
+  - name: Verify Rocket.Chat binary tarball with GPG
+    shell: |
+      gpg --verify rocket.chat-{{ rocket_chat_version }}.asc \
+                   rocket.chat-{{ rocket_chat_version }}.tgz
+    args:
+      chdir: "{{ rocket_chat_application_path }}"
+    when: rocket_Chat_tarball_check_pgp
+    changed_when: false
+    tags: pgp
 
   - name: Upgrade Rocket.Chat
     include: upgrade.yml

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,7 @@ rocket_chat_dep_packages:
   - wget
   # This seems to install something on Docker that causes a failure in the tests
   - cron
+  - gpg
 
 rocket_chat_mongodb_packages:
   - mongodb-org-server

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,6 +9,7 @@ rocket_chat_dep_packages:
   - wget
   - crontabs
   - policycoreutils-python
+  - gpg
 
 rocket_chat_mongodb_packages:
   - mongodb

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -7,6 +7,7 @@ rocket_chat_dep_packages:
   - make
   - wget
   - cron
+  - gpg
 
 rocket_chat_mongodb_packages:
   - mongodb-org-server


### PR DESCRIPTION
 - Downloads the Rocket.Chat Builserver key from public keyservers
 - Downlaods the current tarball signature from a known location
 - Verifies the signature with the keyserver key

 - New vars:
    - `rocket_chat_tarball_asc_remote`
    - `rocket_chat_tarball_gpg_key`
    - `rocket_chat_tarball_gpg_keyserver`
    - `rocket_Chat_tarball_check_pgp`

 - Set `rocket_chat_tarball_check_checksum` to `false`
   - `rocket_chat_tarball_sha256sum` to zero

 - Closes #50, #44, #29
 - Related #44, #52