### PR TITLE
Allow arbitrary service environment variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ rocket_chat_service_user: rocketchat
 rocket_chat_service_group: rocketchat
 rocket_chat_service_host: "{{ ansible_fqdn }}"
 rocket_chat_service_port: 3000
+rocket_chat_service_environment: {}
 rocket_chat_node_version: 8.9.4
 rocket_chat_node_prefix: /usr/local/n/versions/node/{{ rocket_chat_node_version }}
 rocket_chat_node_path: "{{ rocket_chat_node_prefix }}/bin/node"

--- a/templates/rocketchat.service.j2
+++ b/templates/rocketchat.service.j2
@@ -14,6 +14,9 @@ Environment=MONGO_URL=mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket_chat_
 Environment=MONGO_OPLOG_URL=mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket_chat_mongodb_port }}/local
 Environment=ROOT_URL=https://{{ rocket_chat_service_host }}
 Environment=PORT={{ rocket_chat_service_port }}
+{% for variable, value in rocket_chat_service_environment.iteritems() %}
+Environment={{ variable }}={{ value }}
+{% endfor -%}
 WorkingDirectory={{ rocket_chat_application_path }}
 ExecStart={{ rocket_chat_node_path }} {{ rocket_chat_application_path }}/bundle/main.js
 


### PR DESCRIPTION
 - New var: `rocket_chat_service_environment`:
    - This is designed to be a dict, so for every key value pair
      will appear a new line in the rocketchat.service file to
      be exported to the environment of the nodejs process.

 - Closes #67