### PR TITLE
Vagrantfile updates:

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,8 +1,8 @@
-ENV['VAGRANT_NO_PARALLEL'] = 'yes'
-TYPE_NAME = 'RocketChat'
+ENV['VAGRANT_NO_PARALLEL'] = 'yes'.freeze
+TYPE_NAME = 'RocketChat'.freeze
 MEM_SIZE = 1024
-LV_CPU_MODE = 'host-passthrough'
-ANSIBLE_GROUP_NAME = 'chat_servers'
+LV_CPU_MODE = 'host-passthrough'.freeze
+ANSIBLE_GROUP_NAME = 'chat_servers'.freeze
 SHARED_FOLDER_DISABLED = true
 
 Vagrant.configure('2') do |config|
@@ -12,11 +12,13 @@ Vagrant.configure('2') do |config|
   # don't bother sharing folders.
   config.vm.synced_folder '.', '/vagrant', disabled: SHARED_FOLDER_DISABLED
 
-  def do_ansible(name, boxes)
-    name.vm.provision 'ansible' do |ansible|
-      ansible.groups = { ANSIBLE_GROUP_NAME => boxes.keys }
-      # ansible.extra_vars = { }
-      ansible.sudo = true
+  def do_ansible(box, box_props, name)
+    box.vm.provision 'ansible' do |ansible|
+      ansible.groups = { ANSIBLE_GROUP_NAME => name }
+      unless box_props['extra_vars'].nil? || box_props['extra_vars'].empty?
+        ansible.extra_vars = box_props['extra_vars']
+      end
+      ansible.become = true
       ansible.playbook = 'provision.yml'
       ansible.raw_arguments = '-vv'
     end
@@ -29,43 +31,50 @@ Vagrant.configure('2') do |config|
       'id'            => 0,
       'atlas_name'    => 'debian/jessie64'
     },
-    'ubuntu16' => {
+    'debian9' => {
       'id'            => 1,
-      'atlas_name'    => 'bento/ubuntu-16.04',
-      'lv_atlas_name' => 'wholebits/ubuntu16.04-64'
+      'atlas_name'    => 'debian/stretch64'
     },
-    'ubuntu14' => {
+    'ubuntu16' => {
       'id'            => 2,
-      'atlas_name'    => 'bento/ubuntu-14.04',
-      'lv_atlas_name' => 'wholebits/ubuntu14.04-64'
+      'atlas_name'    => 'generic/ubuntu1604',
+      'extra_vars'    => {
+        'ansible_python_interpreter': '/usr/bin/python3'
+      }
+    },
+    'ubuntu18' => {
+      'id'            => 3,
+      'atlas_name'    => 'generic/ubuntu1804',
+      'extra_vars'    => {
+        'ansible_python_interpreter': '/usr/bin/python3'
+      }
     },
     'centos7' => {
-      'id'            => 3,
+      'id'            => 4,
       'atlas_name'    => 'centos/7'
     },
-    'Fedora24' => {
-      'id'            => 4,
-      'atlas_name'    => 'fedora/24-cloud-base'
-    },
-    'Fedora25' => {
+    'fedora27' => {
       'id'            => 5,
-      'atlas_name'    => 'fedora/25-cloud-base'
+      'atlas_name'    => 'fedora/27-cloud-base',
+      'extra_vars'    => {
+        'ansible_python_interpreter': '/usr/bin/python3'
+      }
     }
   }
 
   boxes.each do |name, box_props|
     network_args = {
-      :priv_net => {
-        :ip    => "192.168.60.#{100 + box_props['id']}"
+      priv_net: {
+        ip: "192.168.60.#{100 + box_props['id']}"
       },
       # Don't iterate the port because we want it to remain the same
-      :fwd_pt_http => {
-        :guest => 3000,
-        :host  => 4000 + box_props['id']
+      fwd_pt_http: {
+        guest: 3000,
+        host: 4000 + box_props['id']
       },
-      :fwd_pt_https => {
-        :guest => 443,
-        :host  => 4430 + box_props['id']
+      fwd_pt_https: {
+        guest: 443,
+        host: 4430 + box_props['id']
       }
     }
 
@@ -76,23 +85,17 @@ Vagrant.configure('2') do |config|
       machine.vm.provider :virtualbox do |vb, override|
         vb.customize ['modifyvm', :id, '--memory', MEM_SIZE.to_s]
         vb.name = name + '-' + TYPE_NAME
+        do_ansible(override, box_props, name)
       end
 
       machine.vm.provider :libvirt do |lv, override|
         lv.default_prefix = TYPE_NAME
         lv.memory = MEM_SIZE
         lv.cpu_mode = LV_CPU_MODE
+        # Override atlas_name with lv_atlas_name if it exists as a way to
+        # set different boxes for libvirt's provider.
         override.vm.box = box_props['lv_atlas_name'] || box_props['atlas_name']
-        if box_props['lv_atlas_name'] =~ /wholebits/
-          override.vm.provision 'shell',
-            inline: 'apt-get -yqq update && apt-get -yqq install python-minimal'
-          do_ansible(override, boxes)
-        end
-        if box_props['atlas_name'] =~ /^fedora/
-          override.vm.provision 'shell',
-            inline: 'dnf -d0 -e0 -y install python2-dnf libselinux-python'
-          do_ansible(override, boxes)
-        end
+        do_ansible(override, box_props, name)
       end
 
       machine.vm.box = box_props['atlas_name']

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+nocows = 1
+retry_files_enabled = 0
+stdout_callback = debug
+callback_whitelist = profile_tasks, timer

--- a/tests/provision.yml
+++ b/tests/provision.yml
@@ -16,7 +16,7 @@
         validate: visudo -cf %s
 
   roles:
-    - role: "{{ role_name | default('../../RocketChat.Server') }}"
+    - role: "{{ role_name | default('../..') }}"
       rocket_chat_tarball_check_checksum: false
       rocket_chat_service_host: localhost
       rocket_chat_automatic_upgrades: true


### PR DESCRIPTION
 - Update vagrant boxes to point to newer atlas boxes
   - Chose a different provider for Ubuntu images - "generic"

 - Do extra vers per box, this allows us to
   set ansible_python_interpreter per box most hosts need
   /usr/bin/python3, or python2 installed python3 ansible
   is stable enough to consider using full time now

 - RuboCop fixes
 - Add do_ansible function back as provisioner

Others:
 - Added Ansible config
 - Changed role name to be '../..' in provision.yml as this is
   the proper way to reference a role from its own subdir

 - Fixes #64