### PR TITLE
Add new feature for more than one rocketchat.service process

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All variables have sane defaults set in [`defaults/main.yml`](defaults/main.yml)
 | `rocket_chat_service_group` | `rocketchat` | The name of the primary group for the `rocket_chat_service_user` user |
 | `rocket_chat_service_host` | `"{{ ansible_fqdn }}"` | The FQDN of the Rocket.Chat system |
 | `rocket_chat_service_port` | 3000 | The TCP port Rocket.Chat listens on |
+| `rocket_chat_service_extra_instances` | `[]` | List of TCP port numbers for additional rocketchat service instances to handle more users on one machine |
 | `rocket_chat_node_version` | `4.5.0` | The version of NodeJS to install that `n` understands |
 | `rocket_chat_node_prefix` | `/usr/local/n/versions/node/{{ rocket_chat_node_version }}` | The path to the `node` binary directory that n installs |
 | `rocket_chat_npm_dist` | `/usr/bin/npm` | The path to the original `npm` binary, before n installs any Node versions |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ rocket_chat_service_group: rocketchat
 rocket_chat_service_host: "{{ ansible_fqdn }}"
 rocket_chat_service_port: 3000
 rocket_chat_service_environment: {}
+rocket_chat_service_extra_instances: []
 rocket_chat_node_version: 8.9.4
 rocket_chat_node_prefix: /usr/local/n/versions/node/{{ rocket_chat_node_version }}
 rocket_chat_node_path: "{{ rocket_chat_node_prefix }}/bin/node"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,3 +25,9 @@
     service:
       name: rocketchat
       state: restarted
+
+  - name: Restart the Rocket.Chat@ services
+    service:
+      name: "rocketchat@{{ item }}"
+      state: restarted
+    with_list: "{{ rocket_chat_service_extra_instances }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -261,7 +261,25 @@
       - Restart the Rocket.Chat service
     tags: service
 
+  - name: Deploy the Rocket.Chat@ service file
+    template:
+      src: "{{ rocket_chat_service_template_at.src }}"
+      dest: "{{ rocket_chat_service_template_at.dest }}"
+    notify:
+      - Update the Rocket.Chat service configuration
+      - Restart the Rocket.Chat@ services
+    tags: service
+    when: rocket_chat_service_extra_instances
+
   - meta: flush_handlers
+
+  - name: Stop the Rocket.Chat@ services [UPGRADE]
+    service:
+      name: "rocketchat@{{ item }}"
+      state: restarted
+    when: (rocket_chat_upgraded | bool)
+    with_list: "{{ rocket_chat_service_extra_instances }}"
+    tags: service
 
   - name: Restart the Rocket.Chat service [UPGRADE]
     service:
@@ -275,6 +293,14 @@
       name: rocketchat
       state: started
       enabled: true
+    tags: service
+
+  - name: Ensure the Rocket.Chat@ services are running/enabled
+    service:
+      name: "rocketchat@{{ item }}"
+      state: started
+      enabled: true
+    with_list: "{{ rocket_chat_service_extra_instances }}"
     tags: service
 
   - import_tasks: nginx.yml

--- a/templates/rocket_chat.conf.j2
+++ b/templates/rocket_chat.conf.j2
@@ -1,5 +1,8 @@
 upstream rocket_chat {
         server 127.0.0.1:{{ rocket_chat_service_port }};
+{% for port in rocket_chat_service_extra_instances %}
+        server 127.0.0.1:{{ port }};
+{% endfor %}
 }
 server {
 {% if ansible_default_ipv6.gateway is defined %}

--- a/templates/rocketchat@.service.j2
+++ b/templates/rocketchat@.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Rocket.Chat Server
+After=syslog.target
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+StandardOutput=syslog
+SyslogIdentifier=RocketChat
+User={{ rocket_chat_service_user }}
+Group={{ rocket_chat_service_group }}
+Environment=MONGO_URL=mongodb://{{ rocket_chat_mongodb_URI }}
+Environment=MONGO_OPLOG_URL=mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket_chat_mongodb_port }}/local
+Environment=ROOT_URL=https://{{ rocket_chat_service_host }}
+Environment=PORT=%I
+{% for variable, value in rocket_chat_service_environment.iteritems() %}
+Environment={{ variable }}={{ value }}
+{% endfor -%}
+WorkingDirectory={{ rocket_chat_application_path }}
+ExecStart={{ rocket_chat_node_path }} {{ rocket_chat_application_path }}/bundle/main.js
+
+[Install]
+WantedBy=rocketchat.service

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -31,3 +31,7 @@ rocket_chat_service_update_command: systemctl daemon-reload
 rocket_chat_service_template:
   src: rocketchat.service.j2
   dest: /etc/systemd/system/rocketchat.service
+
+rocket_chat_service_template_at:
+  src: rocketchat@.service.j2
+  dest: /etc/systemd/system/rocketchat@.service

--- a/vars/Fedora_2x.yml
+++ b/vars/Fedora_2x.yml
@@ -3,4 +3,7 @@ rocket_chat_service_update_command: systemctl daemon-reload
 rocket_chat_service_template:
   src: rocketchat.service.j2
   dest: /usr/lib/systemd/system/rocketchat.service
+rocket_chat_service_template_at:
+  src: rocketchat@.service.j2
+  dest: /usr/lib/systemd/system/rocketchat@.service
 rocket_chat_tarball_validate_remote_cert: true

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -3,4 +3,7 @@ rocket_chat_service_update_command: systemctl daemon-reload
 rocket_chat_service_template:
   src: rocketchat.service.j2
   dest: /usr/lib/systemd/system/rocketchat.service
+rocket_chat_service_template_at:
+  src: rocketchat@.service.j2
+  dest: /usr/lib/systemd/system/rocketchat@.service
 rocket_chat_tarball_validate_remote_cert: true

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -31,3 +31,6 @@ rocket_chat_service_update_command: systemctl daemon-reload
 rocket_chat_service_template:
   src: rocketchat.service.j2
   dest: /etc/systemd/system/rocketchat.service
+rocket_chat_service_template_at:
+  src: rocketchat@.service.j2
+  dest: /etc/systemd/system/rocketchat@.service


### PR DESCRIPTION
Allows to start multiple node.js process to utilize more cores.
Configures nginx to loadbalance.
see also:
https://rocket.chat/docs/installation/manual-installation/multiple-instances-to-improve-performance/