### PR TITLE
 Update node and npm versions, move to python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,10 +23,10 @@ rocket_chat_service_host: "{{ ansible_fqdn }}"
 rocket_chat_service_port: 3000
 rocket_chat_service_environment: {}
 rocket_chat_service_extra_instances: []
-rocket_chat_node_version: 8.9.4
+rocket_chat_node_version: 8.11.4
 rocket_chat_node_prefix: /usr/local/n/versions/node/{{ rocket_chat_node_version }}
 rocket_chat_node_path: "{{ rocket_chat_node_prefix }}/bin/node"
-rocket_chat_npm_version: 5.6.0
+rocket_chat_npm_version: 6.4.1
 rocket_chat_npm_path: "{{ rocket_chat_node_prefix }}/bin/npm"
 rocket_chat_npm_dist: /usr/bin/npm
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ rocket_chat_tarball_sha256sum: 0
 rocket_chat_tarball_gpg_key: 0E163286C20D07B9787EBE9FD7F9D0414FD08104
 rocket_chat_tarball_gpg_keyserver: ha.pool.sks-keyservers.net
 rocket_chat_tarball_check_checksum: false
-rocket_Chat_tarball_check_pgp: true
+rocket_chat_tarball_check_pgp: true
 rocket_chat_tarball_fetch_timeout: 100
 rocket_chat_tarball_validate_remote_cert: true
 rocket_chat_pgp_command: gpg2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,7 +164,7 @@
       register: get_pgp_asc_result
       until: (get_pgp_asc_result is succeeded)
       retries: 2
-    when: (rocket_Chat_tarball_check_pgp | bool)
+    when: (rocket_chat_tarball_check_pgp | bool)
     tags: pgp
 
   - name: Fetch the Rocket.Chat binary tarball
@@ -196,7 +196,7 @@
                  rocket.chat-{{ rocket_chat_version }}.tgz
     args:
       chdir: "{{ rocket_chat_application_path }}"
-    when: (rocket_Chat_tarball_check_pgp | bool)
+    when: (rocket_chat_tarball_check_pgp | bool)
     changed_when: false
     tags: pgp
 

--- a/tasks/mongodb.yml
+++ b/tasks/mongodb.yml
@@ -89,9 +89,9 @@
   - name: Ensure the MongoDB replSets have been initiated
     shell: >-
       mongo --quiet --eval
-      'rs.initiate({_id:"{{ rocket_chat_mongodb_repl_setname }}",
+      'JSON.stringify(rs.initiate({_id:"{{ rocket_chat_mongodb_repl_setname }}",
       members: [{"_id":1, "host":
-      "{{ rocket_chat_mongodb_server }}:{{ rocket_chat_mongodb_port }}"}]})'
+      "{{ rocket_chat_mongodb_server }}:{{ rocket_chat_mongodb_port }}"}]}))'
     become: yes
     become_user: "{{ rocket_chat_mongodb_service_user }}"
     args:

--- a/templates/rocketchat.service.j2
+++ b/templates/rocketchat.service.j2
@@ -15,7 +15,7 @@ Environment=MONGO_OPLOG_URL=mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket
 Environment=ROOT_URL=https://{{ rocket_chat_service_host }}
 Environment=PORT={{ rocket_chat_service_port }}
 Environment=DEPLOY_PLATFORM=ansible
-{% for variable, value in rocket_chat_service_environment.iteritems() %}
+{% for variable, value in rocket_chat_service_environment.items() %}
 Environment={{ variable }}={{ value }}
 {% endfor -%}
 WorkingDirectory={{ rocket_chat_application_path }}

--- a/templates/rocketchat@.service.j2
+++ b/templates/rocketchat@.service.j2
@@ -15,7 +15,7 @@ Environment=MONGO_OPLOG_URL=mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket
 Environment=ROOT_URL=https://{{ rocket_chat_service_host }}
 Environment=PORT=%I
 Environment=DEPLOY_PLATFORM=ansible
-{% for variable, value in rocket_chat_service_environment.iteritems() %}
+{% for variable, value in rocket_chat_service_environment.items() %}
 Environment={{ variable }}={{ value }}
 {% endfor -%}
 WorkingDirectory={{ rocket_chat_application_path }}

--- a/templates/rocketchat_upstart.j2
+++ b/templates/rocketchat_upstart.j2
@@ -23,7 +23,7 @@ env MONGO_URL="mongodb://{{ rocket_chat_mongodb_URI }}"
 env MONGO_OPLOG_URL="mongodb://{{ rocket_chat_mongodb_server }}:{{ rocket_chat_mongodb_port }}/local"
 env ROOT_URL="https://{{ rocket_chat_service_host }}"
 env PORT="{{ rocket_chat_service_port }}"
-{% for variable, value in rocket_chat_service_environment.iteritems() %}
+{% for variable, value in rocket_chat_service_environment.items() %}
 env {{ variable }}="{{ value }}"
 {% endfor -%}
 


### PR DESCRIPTION
* Support for targeting Debian 9 (with MongoDB 3.6)
* Support override of the MongoDB database via `rocket_chat_mongodb_database` variable
* Fix some deprecated Ansible syntax and stylistic inconsistencies