### PR TITLE
Fix name of the mongodb service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ rocket_chat_npm_dist: /usr/bin/npm
 
 # MongoDB settings
 rocket_chat_mongodb_packages: mongodb
-rocket_chat_mongodb_service_name: mongod
+rocket_chat_mongodb_service_name: mongodb
 rocket_chat_mongodb_service_user: mongodb
 rocket_chat_include_mongodb: true
 rocket_chat_mongodb_keyserver: hkp://keyserver.ubuntu.com:80


### PR DESCRIPTION
Hey,
my playbook stopped because there is no service called `mongod`, only `mongodb`.
Thank you for this nice role:)
Lukas