### PR TITLE
Add Support for Debian Stretch

### DIFF
--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -25,6 +25,12 @@
     changed_when: false
     failed_when: false
 
+  - name: Deactivate default Nginx site.
+    file:
+      path: /etc/nginx/sites-enabled/default
+      state: absent
+    notify: Reload the Nginx service
+
   - name: Deploy Nginx configuration
     template:
       src: "{{ item.src }}"

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,7 +1,7 @@
 ---
 rocket_chat_mongodb_org_version: 4.0
 rocket_chat_mongodb_gpg_key: 9DA31620334BD75D9DCB49F368818C72E52529D4
-rocket_chat_mongodb_service_name: mongodb
+rocket_chat_mongodb_service_name: mongod
 rocket_chat_mongodb_org_pkgs: true
 rocket_chat_mongodb_packages:
   - mongodb-org

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,7 +1,10 @@
 ---
 rocket_chat_mongodb_org_version: 4.0
 rocket_chat_mongodb_service_name: mongodb
-rocket_chat_mongodb_org_pkgs: false
+rocket_chat_mongodb_org_pkgs: true
+rocket_chat_mongodb_packages:
+  - mongodb-org
+  - mongodb-org-server
 
 rocket_chat_dist_specific_packages:
   - g++

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,5 +1,6 @@
 ---
 rocket_chat_mongodb_org_version: 4.0
+rocket_chat_mongodb_gpg_key: 9DA31620334BD75D9DCB49F368818C72E52529D4
 rocket_chat_mongodb_service_name: mongodb
 rocket_chat_mongodb_org_pkgs: true
 rocket_chat_mongodb_packages:

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,4 +1,5 @@
 ---
+rocket_chat_mongodb_org_version: 4.0
 rocket_chat_mongodb_service_name: mongodb
 rocket_chat_mongodb_org_pkgs: false
 


### PR DESCRIPTION
Fixed some vars for Debian 9 as MongoDB in Version 3.4 as suggested by Main Vars is not available for Stretch. Minimum Version is 3.6 and suggested by RocketChat Documentation is 4.0. 