### PR TITLE
[FIX] Current versions of rocketchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Set in [`vars/RedHat.yml`](vars/RedHat.yml)
 | `rocket_chat_mongodb_dbpath` | `/var/lib/mongodb` | The path for MongoDB to store its databases |
 | `rocket_chat_nginx_process_user` | `nginx` | The user for that will be used to spawn the Nginx server process |
 
-### RHEL/CentOS 7 variables
+### RHEL/CentOS 7/8 variables
 Set in [`vars/RedHat_7.yml`](vars/RedHat_7.yml)
 
 |     Name     |     Default Value    |    Description     |
@@ -128,6 +128,7 @@ Set in [`vars/RedHat_7.yml`](vars/RedHat_7.yml)
 | `  src` | `rocketchat.service.j2` | The source template to deploy for the Rocket.Chat service manifest |
 | `  dest` | `/usr/lib/systemd/system/rocketchat.service` | The destination to deploy the Rocket.Chat service manifest to |
 | `rocket_chat_tarball_validate_remote_cert` | false | A boolean value that determines wether or not to validate the SSL certs for the Rocket.Chat tarball remote |
+| `rocket_chat_epel_key` | `/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7` | EPEL repository GPG key to be used |
 
 ### Debian variables
 Set in [`vars/Debian.yml`](vars/Debian.yml)

--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ Features
 Supported Platforms
 -------------------
 ### Debian
-- Strect (9)
+- Strecth (9)
 - Buster (10)
 
 ### Ubuntu
+- Focal Fossa: 20.04 LTS
 - Bionic Beaver: 18.04 LTS
 - Xenial: 16.04 LTS
-- Trusty: 14.04 LTS
 
 ### EL (RHEL/CentOS)
 - 7
+- 8
 
 If you'd like to see your distribution/operating system supported, please [raise an issue](https://github.com/RocketChat/Rocket.Chat.Ansible/issues)!
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ rocket_chat_tarball_asc_remote:  https://releases.rocket.chat/{{ rocket_chat_ver
 # Using the sha256sum is deprecated in favor of GPG verifying
 rocket_chat_tarball_sha256sum: 0
 rocket_chat_tarball_gpg_key: 0E163286C20D07B9787EBE9FD7F9D0414FD08104
-rocket_chat_tarball_gpg_keyserver: ha.pool.sks-keyservers.net
+rocket_chat_tarball_gpg_keyserver: keyserver.ubuntu.com
 rocket_chat_tarball_check_checksum: false
 rocket_chat_tarball_check_pgp: true
 rocket_chat_tarball_fetch_timeout: 100
@@ -23,7 +23,7 @@ rocket_chat_service_host: "{{ ansible_fqdn }}"
 rocket_chat_service_port: 3000
 rocket_chat_service_environment: {}
 rocket_chat_service_extra_instances: []
-rocket_chat_node_version: 12.16.1
+rocket_chat_node_version: 12.22.1
 rocket_chat_node_prefix: /usr/local/n/versions/node/{{ rocket_chat_node_version }}
 rocket_chat_node_path: "{{ rocket_chat_node_prefix }}/bin/node"
 rocket_chat_npm_version: 6.14.0
@@ -76,3 +76,4 @@ rocket_chat_letsencrypt_acmetiny_path: /opt/acme-tiny
 rocket_chat_letsencrypt_wellknown_path: /var/www/letsencrypt
 rocket_chat_letsencrypt_ca_cert: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
 rocket_chat_letsencrypt_force_renew: false
+rocket_chat_n_path: 'n'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
       - name: Ensure the EPEL repository GPG key is imported
         rpm_key:
-          key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+          key: "{{ rocket_chat_epel_key }}"
           state: present
 
     when: ((ansible_distribution | lower) == "centos")

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -85,7 +85,7 @@
     when:
       - (rocket_chat_nginx_pfs_file is defined)
       - (rocket_chat_nginx_pfs_file)
-      - (rocket_chat_nginx_pfs_file | exists)
+      - (rocket_chat_nginx_pfs_file is exists)
     notify: Reload the Nginx service
     tags: pfs
 

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -38,7 +38,7 @@
   register: n_node_bin
 
 - name: "Install the supported NodeJS environment via n [Version: {{ rocket_chat_node_version }}]"
-  shell: n {{ rocket_chat_node_version }}
+  shell: '{{ rocket_chat_n_path }} {{ rocket_chat_node_version }}'
   when: ('stat' in n_node_bin)
          and (not (n_node_bin.stat.exists | bool))
 

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -4,7 +4,6 @@ MEM_SIZE = 1024
 LV_CPU_MODE = 'host-passthrough'.freeze
 ANSIBLE_GROUP_NAME = 'chat_servers'.freeze
 SHARED_FOLDER_DISABLED = true
-
 Vagrant.configure('2') do |config|
   config.ssh.insert_key = false
   config.ssh.username = 'vagrant'
@@ -21,6 +20,7 @@ Vagrant.configure('2') do |config|
       ansible.verbose = "vv"
       ansible.become = true
       ansible.playbook = 'provision.yml'
+      ansible.compatibility_mode = "2.0"
       # ansible.raw_arguments = ['-t check']
     end
   end
@@ -36,12 +36,9 @@ Vagrant.configure('2') do |config|
       'id'            => 1,
       'atlas_name'    => 'debian/stretch64'
     },
-    'ubuntu14' => {
+    'debian10' => {
       'id'            => 2,
-      'atlas_name'    => 'ubuntu/trusty64',
-      # Some random guy's image that looked ok
-      # Libvirt boxes are hard to come by for trusty64.
-      'lv_atlas_name' => 'peru/ubuntu-14.04-server-amd64'
+      'atlas_name'    => 'debian/buster64'
     },
     'ubuntu16' => {
       'id'            => 3,
@@ -50,23 +47,27 @@ Vagrant.configure('2') do |config|
         'ansible_python_interpreter': '/usr/bin/python3'
       }
     },
-    # 'ubuntu18' => {
-    #   'id'            => 4,
-    #   'atlas_name'    => 'generic/ubuntu1804',
-    #   'extra_vars'    => {
-    #     'ansible_python_interpreter': '/usr/bin/python3'
-    #   }
-    # },
-    'centos7' => {
-      'id'            => 5,
-      'atlas_name'    => 'centos/7'
-    },
-    'fedora27' => {
-      'id'            => 6,
-      'atlas_name'    => 'fedora/27-cloud-base',
+    'ubuntu18' => {
+      'id'            => 4,
+      'atlas_name'    => 'generic/ubuntu1804',
       'extra_vars'    => {
         'ansible_python_interpreter': '/usr/bin/python3'
       }
+    },
+    'ubuntu20' => {
+      'id'            => 5,
+      'atlas_name'    => 'generic/ubuntu2004',
+      'extra_vars'    => {
+        'ansible_python_interpreter': '/usr/bin/python3'
+      }
+    },
+    'centos7' => {
+      'id'            => 6,
+      'atlas_name'    => 'centos/7'
+    },
+    'centos8' => {
+      'id'            => 7,
+      'atlas_name'    => 'centos/8'
     }
   }
 

--- a/tests/provision.yml
+++ b/tests/provision.yml
@@ -42,6 +42,11 @@
           line: '%{{ ansible_user }} ALL=(ALL) NOPASSWD: ALL'
           validate: visudo -cf %s
 
+      - name: Copy PEM file
+        copy:
+          src: "{{ rocket_chat_nginx_pfs_file }}"
+          dest: "{{ rocket_chat_nginx_pfs_file }}"
+
       - name: Include the Rocket.Chat role
         include_role:
           name: "{{ role_name | default('../..') }}"
@@ -53,7 +58,7 @@
             port: "{{ rocket_chat_service_port }}"
             host: localhost
             state: started
-            timeout: 30
+            timeout: 60
           register: api_pre_check
 
         - name: Do a basic status check of the API
@@ -68,7 +73,7 @@
             - (api_check.status|int != 200)
                or (api_check.msg|string is not search('^OK '))
                or (api_check.json.success|bool != True)
-          when: (api_pre_check | succeeded)
+          when: (api_pre_check is succeeded)
 
         - name: Destroy the last successful vagrant box
           local_action: shell
@@ -79,7 +84,7 @@
           when:
             - (api_pre_check is succeeded) and (api_check is succeeded)
             - ((ansible_virtualization | default(None) | lower) != "docker")
-            - (lookup('pipe','command -v vagrant') | search('vagrant$'))
+            - (lookup('pipe','command -v vagrant') is search('vagrant$'))
 
         # We use YAML anchoring to duplicate this below
         # because Ansible does not supported nested rescue.
@@ -101,7 +106,7 @@
             poll: 0
             when:
               - ((ansible_virtualization | default(None) | lower) != "docker")
-              - (lookup('pipe','command -v vagrant') | search('vagrant$'))
+              - (lookup('pipe','command -v vagrant') is search('vagrant$'))
         tags: check
         # API BLOCK END
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,7 @@ rocket_chat_dep_packages:
   # This seems to install something on Docker that causes a failure in the tests
   - cron
   - gnupg2
+  - dirmngr
 
 rocket_chat_mongodb_org_pkgs: true
 rocket_chat_mongodb_apt_repo: "\

--- a/vars/Debian_8.yml
+++ b/vars/Debian_8.yml
@@ -3,3 +3,5 @@
 rocket_chat_dist_specific_packages:
   - nodejs
   - npm
+
+rocket_chat_mongodb_service_name: mongod

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -17,17 +17,19 @@ rocket_chat_mongodb_packages:
 rocket_chat_mongodb_repl_setname: 001-rs
 rocket_chat_mongodb_repl_lines: 'replSet={{ rocket_chat_mongodb_repl_setname }}'
 rocket_chat_mongodb_fork: true
-rocket_chat_mongodb_pidfile_path: /var/run/mongodb/mongodb.pid
+rocket_chat_mongodb_pidfile_path: /var/run/mongodb/mongod.pid
 rocket_chat_mongodb_logpath: /var/log/mongodb/mongod.log
 rocket_chat_mongodb_unixsocketprefix: /var/run/mongodb
-rocket_chat_mongodb_dbpath: /var/lib/mongodb
-rocket_chat_mongodb_org_pkgs: false
+rocket_chat_mongodb_dbpath: /var/lib/mongo
+rocket_chat_mongodb_org_pkgs: true
+rocket_chat_mongodb_service_name: mongod
+rocket_chat_mongodb_service_user: mongod
 
 rocket_chat_nginx_process_user: nginx
 
 rocket_chat_mongodb_rpm_repo:
-  name: mongodb-org-3.4
-  desc: MongoDB 3.4 Repository
-  baseurl: https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.4/x86_64/
-  pgp_key: https://www.mongodb.org/static/pgp/server-3.4.asc
+  name: mongodb-org-4.4
+  desc: MongoDB 4.4 Repository
+  baseurl: https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/x86_64/
+  pgp_key: https://www.mongodb.org/static/pgp/server-4.4.asc
   gpgcheck: true

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -7,10 +7,21 @@ rocket_chat_service_template_at:
   src: rocketchat@.service.j2
   dest: /usr/lib/systemd/system/rocketchat@.service
 rocket_chat_tarball_validate_remote_cert: true
-rocket_chat_epel_key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+rocket_chat_epel_key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8
 rocket_chat_mongodb_rpm_repo:
   name: mongodb-org-4.4
   desc: MongoDB 4.4 Repository
-  baseurl: https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.4/x86_64/
+  baseurl: https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/x86_64/
   pgp_key: https://www.mongodb.org/static/pgp/server-4.4.asc
   gpgcheck: true
+rocket_chat_dep_packages:
+  - git
+  - GraphicsMagick
+  - nodejs
+  - npm
+  - make
+  - gcc-c++
+  - wget
+  - crontabs
+  - gnupg2
+rocket_chat_n_path: /usr/local/bin/n

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -15,6 +15,7 @@ rocket_chat_mongodb_apt_repo: "\
   {{ ansible_distribution_release | lower }}/mongodb-org/\
   {{ rocket_chat_mongodb_org_version }} multiverse"
   
+rocket_chat_mongodb_service_name: mongod
 rocket_chat_mongodb_packages:
   - mongodb
   - mongodb-server

--- a/vars/Ubuntu_14.yml
+++ b/vars/Ubuntu_14.yml
@@ -1,7 +1,0 @@
----
-rocket_chat_service_update_command: initctl reload-configuration
-rocket_chat_service_template:
-  src: rocketchat_upstart.j2
-  dest: /etc/init/rocketchat.conf
-
-rocket_chat_tarball_validate_remote_cert: false

--- a/vars/Ubuntu_18.yml
+++ b/vars/Ubuntu_18.yml
@@ -1,2 +1,3 @@
 ---
 rocket_chat_mongodb_org_pkgs: false
+rocket_chat_mongodb_service_name: mongodb

--- a/vars/Ubuntu_20.yml
+++ b/vars/Ubuntu_20.yml
@@ -1,0 +1,12 @@
+---
+rocket_chat_mongodb_org_pkgs: false
+rocket_chat_dep_packages:
+  - git
+  - graphicsmagick
+  - nodejs
+  - make
+  - wget
+  - cron
+  - gnupg2
+  - g++
+rocket_chat_mongodb_service_name: mongodb


### PR DESCRIPTION
This PR fixes the ansible role to work with current versions of rocketchat and supported OSs.

Other notable changes include:

- Changed GPG keyserver from `ha.pool.sks-keyservers.net` to `keyserver.ubuntu.com`, since it was deprecated and no longer works.
- Add support for Centos8
- Add support for Ubuntu 20.04
- Drop support for Ubuntu 14.04
- Updated node version to  12.22.1
- Updated mongodb version to 4.4
- Fixed syntax for compatibility with ansible 2.10+
- Other bugfixes

- Vagrant tests:
	- Added Ubuntu 20.04
	- Added Debian 10
	- Added Centos 8
	- Removed Fedora 27
	- Removed Ubuntu 14
